### PR TITLE
Ensure review-prompting is never repeated

### DIFF
--- a/app/src/main/java/app/screenreader/extensions/_Activity.kt
+++ b/app/src/main/java/app/screenreader/extensions/_Activity.kt
@@ -23,7 +23,6 @@ fun Activity.requestReview() {
         .setTitle(getSpannable(R.string.app_review))
         .setPositiveButton(getSpannable(R.string.action_continue)) { _, _ ->
             // Request review flow
-            Preferences.setReviewPrompted(true)
             val manager = ReviewManagerFactory.create(this)
             val request = manager.requestReviewFlow()
 
@@ -39,4 +38,7 @@ fun Activity.requestReview() {
             // Ignored
         }
         .show()
+
+    // Prevent re-prompting, no matter how the user responds
+    Preferences.setReviewPrompted(true)
 }


### PR DESCRIPTION
The flag to prevent review-prompt repeats was being set only in the _positive_ selection handler, which means that if the user Canceled the prompt, it would repeat at every opportunity.

Ensure that `.setReviewPrompted()` is called under all circumstances, even when the user Cancels the prompt.

Fixes #2 